### PR TITLE
fix .icon-right

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -77,7 +77,7 @@ a {
 .icon-button:hover {
   filter: brightness(1.2);
 }
-
+.icon-right svg,
 .icon-button svg { 
   fill: var(--text-color);
   width: 20px;
@@ -134,6 +134,10 @@ a {
 .menu-primary-enter {
   position: absolute;
   transform: translateX(-110%);
+  box-sizing: border-box;
+  padding: 1rem;
+  top: 0;
+  left: 0;
 }
 .menu-primary-enter-active {
   transform: translateX(0%);


### PR DESCRIPTION
Hi, I'm a fan from Fireship youtube channel, and it help me a lot.

During repeating this work, I found a little display issue on .icon-right.

this is what I saw on firefox
<img width="328" alt="螢幕快照 2020-04-18 20 05 50" src="https://user-images.githubusercontent.com/45942719/79637438-3c0f0300-81b2-11ea-8ae2-73b7842d09f5.png">

this is what I saw on chrome
<img width="320" alt="螢幕快照 2020-04-18 20 11 09" src="https://user-images.githubusercontent.com/45942719/79637440-3e715d00-81b2-11ea-89d1-a3efce2f6d6b.png">

this is what after change
<img width="319" alt="螢幕快照 2020-04-18 20 12 01" src="https://user-images.githubusercontent.com/45942719/79637442-3fa28a00-81b2-11ea-9f9b-7f4967b4294f.png">

